### PR TITLE
Add Crystal version

### DIFF
--- a/clean.bash
+++ b/clean.bash
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-rm -rf *.o bin_* nimcache
+rm -rf *.o bin_* nimcache .crystal

--- a/compile.bash
+++ b/compile.bash
@@ -9,3 +9,4 @@ go build -o bin_test_go_gc test.go
 rustc --opt-level 3 -o bin_test_rs test.rs
 mcs -out:bin_test_cs test.cs
 nimrod c -d:release --passC:-std=c99 --passC:-Ofast --passC:-march=native --passC:-msse3 --passC:-mfpmath=sse -o:bin_test_nim test.nim
+crystal -o bin_test_cr --release test.cr

--- a/run.bash
+++ b/run.bash
@@ -20,3 +20,5 @@ echo -e "\n=== Rust:"
 perf stat -r 10 ./bin_test_rs 2>&1 >/dev/null | grep time
 echo -e "\n=== Nimrod:"
 perf stat -r 10 ./bin_test_nim 2>&1 > /dev/null | grep time
+echo -e "\n=== Crystal:"
+perf stat -r 10 ./bin_test_cr 2>&1 > /dev/null | grep time

--- a/test.cr
+++ b/test.cr
@@ -1,0 +1,99 @@
+struct Vec2
+  ZERO = Vec2.new(0.0, 0.0)
+
+  def initialize(@x, @y)
+  end
+  getter :x
+  getter :y
+end
+
+def lerp(a, b, v)
+  a * (1.0 - v) + b * v
+end
+
+def smooth(v)
+  v * v * (3.0 - 2.0 * v)
+end
+
+def random_gradient
+  v = rand * Math::PI * 2.0
+  Vec2.new(Math.cos(v), Math.sin(v))
+end
+
+def gradient(orig, grad, p)
+  sp = Vec2.new(p.x - orig.x, p.y - orig.y)
+  grad.x * sp.x + grad.y * sp.y
+end
+
+class Noise2DContext
+  def initialize
+    @rgradients = Array.new(256) { random_gradient }
+    @permutations = (0...256).to_a.shuffle!
+    @origins = {Vec2::ZERO, Vec2::ZERO, Vec2::ZERO, Vec2::ZERO}
+    @gradients = {Vec2::ZERO, Vec2::ZERO, Vec2::ZERO, Vec2::ZERO}
+  end
+
+  def get_gradient(x, y)
+    idx = @permutations[x & 255] + @permutations[y & 255]
+    @rgradients[idx & 255]
+  end
+
+  def get_gradients(x, y)
+    x0f = x.floor
+    y0f = y.floor
+    x0 = x0f.to_i
+    y0 = y0f.to_i
+    x1 = x0 + 1
+    y1 = y0 + 1
+
+    @gradients = {
+      get_gradient(x0, y0),
+      get_gradient(x1, y0),
+      get_gradient(x0, y1),
+      get_gradient(x1, y1),
+    }
+
+    @origins = {
+      Vec2.new(x0f + 0.0, y0f + 0.0),
+      Vec2.new(x0f + 1.0, y0f + 0.0),
+      Vec2.new(x0f + 0.0, y0f + 1.0),
+      Vec2.new(x0f + 1.0, y0f + 1.0),
+    }
+  end
+
+  def get(x, y)
+    p = Vec2.new(x, y)
+    get_gradients(x, y)
+    v0 = gradient(@origins[0], @gradients[0], p)
+    v1 = gradient(@origins[1], @gradients[1], p)
+    v2 = gradient(@origins[2], @gradients[2], p)
+    v3 = gradient(@origins[3], @gradients[3], p)
+    fx = smooth(x - @origins[0].x)
+    vx0 = lerp(v0, v1, fx)
+    vx1 = lerp(v2, v3, fx)
+    fy = smooth(y - @origins[0].y)
+    lerp(vx0, vx1, fy)
+  end
+end
+
+symbols = [" ", "░", "▒", "▓", "█", "█"]
+pixels = Array.new(256) { Array.new(256, 0.0) }
+
+n2d = Noise2DContext.new
+
+100.times do |i|
+  256.times do |y|
+    256.times do |x|
+      v = n2d.get(x * 0.1, (y + (i * 128)) * 0.1) * 0.5 + 0.5
+      pixels[y][x] = v
+    end
+  end
+end
+
+256.times do |y|
+  256.times do |x|
+    v = pixels[y][x]
+    print(symbols[(v / 0.2).to_i])
+  end
+  puts
+end


### PR DESCRIPTION
Hi!

I want to add a Crystal version to the benchmarks. It's not the fastest, but that's what benchmarks are for :-)

In the build script I just put "crystal". To make it work you have to install Crystal as explained [here](https://github.com/manastech/crystal), then you can make a symbolic link to "bin/crystal" named crystal (I put it in /usr/local/bin/crystal).
