### PR TITLE
Remove disabling the GC for D

### DIFF
--- a/test.d
+++ b/test.d
@@ -97,8 +97,6 @@ public:
 
 void main()
 {
-	core.memory.GC.disable();
-
 	immutable symbols = [" ", "░", "▒", "▓", "█", "█"];
 	auto pixels = new float[256*256];
 


### PR DESCRIPTION
Disabling the GC is not important for this benchmark, and including it in this benchmark sends the wrong message about typical usage of the language.
