### PR TITLE
fix flags for dmd, gdc, ldc

### DIFF
--- a/compile.bash
+++ b/compile.bash
@@ -1,9 +1,9 @@
 #!/bin/bash
 gcc -std=c99 -march=native -msse3 -mfpmath=sse -O3 -o bin_test_c_gcc test.c -lm
 clang -std=c99 -march=native -msse3 -mfpmath=sse -O3 -o bin_test_c_clang test.c -lm
-dmd -ofbin_test_d_dmd -O -noboundscheck -inline -release test.d
-ldc2 -O3 -ofbin_test_d_ldc test.d -release
-gdc -O3 -o bin_test_d_gdc test.d -frelease -msse3 -mfpmath=sse -finline
+dmd -ofbin_test_d_dmd -O -boundscheck=off -inline -release test.d
+ldc2 -O5 -ofbin_test_d_ldc test.d -release -mcpu=native -inline -boundscheck=off
+gdc -Ofast -o bin_test_d_gdc test.d -frelease -finline -march=native -fno-bounds-check
 gccgo -O3 -g -o bin_test_go_gccgo test.go
 go build -o bin_test_go_gc test.go
 rustc --opt-level 3 -o bin_test_rs test.rs


### PR DESCRIPTION
saw that C was using native arch flags but not D, and disabled bounds checking.
dmd and ldc times remained the same, gdc decreased about 20% for me.